### PR TITLE
Update to public version of EOdal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,14 +13,16 @@ WORKDIR /eodal
 # install eodal
 # Step 1: COPY source code
 COPY . .
-# Step 2: install eodal from source
+# Step 2: install eodal from PyPI
 # rasterio must be by-passed because of problems in the C-headers with Python 3.10
 RUN pip3 install --upgrade pip
 RUN pip3 install rasterio==1.3a3
 RUN pip3 install folium
-ENV USE_STAC=True
 RUN pip3 install eodal
 RUN pip3 install jupyterlab
+
+# prepare the environment
+ENV USE_STAC=True
 
 # start the jupyter server
 EXPOSE 8888

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,8 @@ COPY . .
 RUN pip3 install --upgrade pip
 RUN pip3 install rasterio==1.3a3
 RUN pip3 install folium
-ARG GITHUB_TOKEN=default_token
-ENV GITHUB_TOKEN=${GITHUB_TOKEN}
 ENV USE_STAC=True
-RUN pip3 install git+https://${GITHUB_TOKEN}@github.com/EOA-team/eodal.git@master
+RUN pip3 install eodal
 RUN pip3 install jupyterlab
 
 # start the jupyter server

--- a/README.md
+++ b/README.md
@@ -26,42 +26,27 @@ Further resources are available showing the [general capacities of E:earth_afric
 
 ## Getting started
 
-E:earth_africa:dal is still undergoing pre-release development. To request access to E:earth_africa:dal send a mail to either `lukasvalentin.graf[at]usys.ethz.ch` or `helge.aasen[at]agroscope.admin.ch` with subject `[EOdal access request] <your name>` to get access to the full code base and the latest features.
+E:earth_africa:dal can be installed from [PyPI](https://pypi.org/project/eodal/)
 
-Please provide:
+```bash
+pip install eodal
+```
 
-* your full name
-* your Github user name (to be used to grant access)
-* your institution/ organization (if applicable)
-* a short statement (2-3 sentences) about your intended usage of E:earth_africa:dal including your area of application/ research.
+or get the latest source code version from [Github](https://github.com/EOA-team/eodal) by running
 
-All your information is handled confidentially and will not be passed on to any third party.
+```bash
+pip install git+https://github.com/EOA-team/eodal
+```
 
-Once you have access to E:earth_africa:dal follow the Step-by-Step Guide below
+A step-by-step guide showing how to run the notebooks in a Docker container can be found below.
 
 ### Step-by-Step Guide
 
-1. Install Docker on your machine. An installation guide to get Docker running on your system can be found [here](https://docs.docker.com/engine/install/).  We strongly recommend to use [Docker](https://www.docker.com/) to run the notebooks in a [JupyterLab](https://jupyter.org/) environment to avoid any dependency problems (especially with [rasterio](https://rasterio.readthedocs.io/en/latest/)).
+#### Install Docker
 
+Install Docker on your machine. An installation guide to get Docker running on your system can be found [here](https://docs.docker.com/engine/install/).  We strongly recommend to use [Docker](https://www.docker.com/) to run the notebooks in a [JupyterLab](https://jupyter.org/) environment to avoid any dependency problems (especially with [rasterio](https://rasterio.readthedocs.io/en/latest/)).
 
-2. Clone the repository from Github:
-
-```{bash}
-git clone https://github.com/EOA-team/eodal_notebooks
-```
-
-3. Modify the .env file. Place a `.env` file in the root of this repository (i.e., where this README is located). Enter your [personal Github access token](https://github.com/settings/tokens) into the file (here shown for working in the Linux shell, Windows cmd works similar):
-
-```{bash}
-cd eodal_notebooks
-
-touch .env
-echo ${GITHUB_TOKEN} > .env
-```
-
-`${GITHUB_TOKEN}` is your personal Github access token. **NOTE**: In order to make this work, you must have access to `E:earth_africa:dal`.
-
-### Start Docker
+#### Start Docker
 
 Once the docker daemon is running (on linux systems by running, e.g., `sudo service docker start`) build the container first using
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ or get the latest source code version from [Github](https://github.com/EOA-team/
 pip install git+https://github.com/EOA-team/eodal
 ```
 
-A step-by-step guide showing how to run the notebooks in a Docker container can be found below.
+Furthermore, a step-by-step guide shows you how to run the notebooks in a Docker container that can be found below.
 
 ### Step-by-Step Guide
 


### PR DESCRIPTION
With the release of [EOdal on PyPI](https://pypi.org/project/eodal/) the usage of the notebooks is now possible without any additional action from users' side. The instructions in the README and in the Dockerfile have been updated.